### PR TITLE
Update and rename GapMeasurementSystem.java to MeasurementSystem.java

### DIFF
--- a/src/main/java/org/fintrace/core/drivers/tspl/commands/system/MeasurementSystem.java
+++ b/src/main/java/org/fintrace/core/drivers/tspl/commands/system/MeasurementSystem.java
@@ -18,7 +18,7 @@ package org.fintrace.core.drivers.tspl.commands.system;
 /**
  * @author Venkaiah Chowdary Koneru
  */
-public enum GapMeasurementSystem {
+public enum MeasurementSystem {
     /**
      * English system (inch)
      */


### PR DESCRIPTION
The enum with this name, GapMeasurement, has misled me.