### PR TITLE
Fix ROMAN.TTF not being printed

### DIFF
--- a/src/main/java/org/fintrace/core/drivers/tspl/commands/label/Text.java
+++ b/src/main/java/org/fintrace/core/drivers/tspl/commands/label/Text.java
@@ -229,15 +229,15 @@ public class Text implements TSPLCommand {
         }
 
         // For "ROMAN.TTF" true type font, xMultiplicationFactor parameter is ignored.
-        if (!"ROMAN.TTF".equals(fontName)) {
-            if (!hasFloatDecimals(xMultiplicationFactor)) {
-                commandBuilder.append(xMultiplicationFactor.intValue());
-            } else {
-                commandBuilder.append(xMultiplicationFactor);
-            }
-
-            commandBuilder.append(COMMA);
+       
+        if (!hasFloatDecimals(xMultiplicationFactor)) {
+            commandBuilder.append(xMultiplicationFactor.intValue());
+        } else {
+            commandBuilder.append(xMultiplicationFactor);
         }
+
+        commandBuilder.append(COMMA);
+
 
 
         if (!hasFloatDecimals(yMultiplicationFactor)) {


### PR DESCRIPTION
Even though xMultiplication is ignored for ROMAN.TTF it still needs to be integrated in the command, as otherwise it doesn't print with the shorter command.