### PR TITLE
Client can work with different charsets

### DIFF
--- a/src/main/java/org/fintrace/core/drivers/tspl/connection/AbstractConnectionClient.java
+++ b/src/main/java/org/fintrace/core/drivers/tspl/connection/AbstractConnectionClient.java
@@ -20,7 +20,6 @@ import org.fintrace.core.drivers.tspl.listeners.ClientListener;
 import org.fintrace.core.drivers.tspl.listeners.DataListener;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -183,14 +182,20 @@ public abstract class AbstractConnectionClient implements TSPLConnectionClient {
         ));
     }
 
-    public void send(String message){send(message.getBytes(charset));}
+    public void send(String message) {
+        send(message.getBytes(charset));
+    }
 
     protected abstract void send(byte[] message);
 
     /** Sets the charset for transmitting Strings as bytes.
      * Does not add the corresponding CODEPAGE command. */
-    public void setCharset(Charset charset) {this.charset = charset;}
+    public void setCharset(Charset charset) {
+        this.charset = charset;
+    }
 
-    public Charset getCharset(){return charset;}
+    public Charset getCharset() {
+        return charset;
+    }
 
 }

--- a/src/main/java/org/fintrace/core/drivers/tspl/connection/AbstractConnectionClient.java
+++ b/src/main/java/org/fintrace/core/drivers/tspl/connection/AbstractConnectionClient.java
@@ -19,10 +19,14 @@ import org.fintrace.core.drivers.tspl.exceptions.ConnectionClientException;
 import org.fintrace.core.drivers.tspl.listeners.ClientListener;
 import org.fintrace.core.drivers.tspl.listeners.DataListener;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**
  * Generic client connection implementation for TSPL2 device
@@ -42,6 +46,8 @@ public abstract class AbstractConnectionClient implements TSPLConnectionClient {
     protected ExecutorService listenerExecutorService = Executors.newCachedThreadPool();
     protected boolean isConnected = Boolean.FALSE;
     protected boolean alive = Boolean.FALSE;
+
+    private Charset charset = US_ASCII;
 
     /**
      * {@inheritDoc}
@@ -176,4 +182,15 @@ public abstract class AbstractConnectionClient implements TSPLConnectionClient {
                 clientListener.connectionLost(AbstractConnectionClient.this)
         ));
     }
+
+    public void send(String message){send(message.getBytes(charset));}
+
+    protected abstract void send(byte[] message);
+
+    /** Sets the charset for transmitting Strings as bytes.
+     * Does not add the corresponding CODEPAGE command. */
+    public void setCharset(Charset charset) {this.charset = charset;}
+
+    public Charset getCharset(){return charset;}
+
 }

--- a/src/main/java/org/fintrace/core/drivers/tspl/connection/EthernetConnectionClient.java
+++ b/src/main/java/org/fintrace/core/drivers/tspl/connection/EthernetConnectionClient.java
@@ -177,17 +177,9 @@ public class EthernetConnectionClient extends AbstractConnectionClient
     }
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void send(String tsplMessage) {
-        send(tsplMessage.getBytes(US_ASCII));
-    }
-
-    /**
      * @param message
      */
-    private void send(byte[] message) {
+    protected void send(byte[] message) {
         if (!isConnected) {
             throw new PrinterException("Printer is not connected");
         }

--- a/src/main/java/org/fintrace/core/drivers/tspl/connection/TSPLConnectionClient.java
+++ b/src/main/java/org/fintrace/core/drivers/tspl/connection/TSPLConnectionClient.java
@@ -20,6 +20,8 @@ import org.fintrace.core.drivers.tspl.commands.label.TSPLLabel;
 import org.fintrace.core.drivers.tspl.listeners.ClientListener;
 import org.fintrace.core.drivers.tspl.listeners.DataListener;
 
+import java.nio.charset.Charset;
+
 /**
  * This interface define the Connection level contract with the
  * TSPL system. Implementation can be done
@@ -114,4 +116,9 @@ public interface TSPLConnectionClient {
      * If the specified listener doesn't exist, the method will not do anything.
      */
     void removeDataListener(DataListener listener);
+
+    /** Sets the charset for transmitting Strings as bytes.
+     * Does not add the corresponding CODEPAGE command. */
+    void setCharset(Charset charset);
+    Charset getCharset();
 }

--- a/src/main/java/org/fintrace/core/drivers/tspl/connection/USBConnectionClient.java
+++ b/src/main/java/org/fintrace/core/drivers/tspl/connection/USBConnectionClient.java
@@ -156,21 +156,10 @@ public class USBConnectionClient extends AbstractConnectionClient implements Usb
     }
 
     /**
-     * Note that submissions (except interrupt and bulk in-direction) will not block indefinitely,
-     * they will complete or fail within a finite amount of time.
-     * <p>
-     * {@inheritDoc}
-     */
-    @Override
-    public void send(String tsplMessage) {
-        send(tsplMessage.getBytes(US_ASCII));
-    }
-
-    /**
      * @param message
      */
 
-    private void send(byte[] message) {
+    protected void send(byte[] message) {
         if (!isConnected) {
             throw new PrinterException("Printer is not connected");
         }

--- a/src/test/java/org/fintrace/core/drivers/tspl/test/connection/AbstractConnectionClientTest.java
+++ b/src/test/java/org/fintrace/core/drivers/tspl/test/connection/AbstractConnectionClientTest.java
@@ -1,0 +1,30 @@
+package org.fintrace.core.drivers.tspl.test.connection;
+
+import lombok.extern.slf4j.Slf4j;
+import org.fintrace.core.drivers.tspl.connection.TSPLConnectionClient;
+import org.fintrace.core.drivers.tspl.connection.USBConnectionClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+@Slf4j public class AbstractConnectionClientTest {
+    short vendorId;
+    byte[] bytes;
+
+    TSPLConnectionClient client = new USBConnectionClient(vendorId) {
+        @Override protected void send(byte[] bs) { bytes = bs; }
+    };
+
+    @Test public void checkCharset(){
+        Assertions.assertEquals(US_ASCII, client.getCharset());
+        client.setCharset(UTF_8);
+        Assertions.assertEquals(UTF_8, client.getCharset());
+        client.send("ë");
+        Assertions.assertArrayEquals(bytes, new byte[]{(byte) 0xC3, (byte) 0xAB});
+        String recover = new String(bytes, UTF_8);
+        Assertions.assertEquals(recover, "ë");
+    }
+
+}

--- a/src/test/java/org/fintrace/core/drivers/tspl/test/connection/AbstractConnectionClientTest.java
+++ b/src/test/java/org/fintrace/core/drivers/tspl/test/connection/AbstractConnectionClientTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 fintrace (https://fintrace.org/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.fintrace.core.drivers.tspl.test.connection;
 
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
AbstractConnectionClient maintains current charset, initialised to US_ASCII.

There are getter and setter for charset.

Method void send(String) uses current charset to convert String to bytes.

The method does not add the corresponding CODEPAGE command. The user must still do that.