### PR TITLE
chore: Upgrade checkstyle plugin to `9.3`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ Network Trash Folder
 Temporary Items
 .apdisk
 ### Java template
+target
 *.class
 
 # BlueJ files

--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.29</version>
+                        <version>9.3</version>
                     </dependency>
                 </dependencies>
                 <configuration>


### PR DESCRIPTION
This is last version that supports JDK8