### PR TITLE
chore: Upgrade actions to use `Node20` runtime 

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -4,8 +4,8 @@
     "color": "EEEEEE"
   },
   "CHECKS": {
-    "prefixes": ["build:","chore:","ci:","docs:","feat:","fix:","refactor:","style:","perf:","test:", "\[Synk\]"],
+    "prefixes": ["build:","chore:","ci:","docs:","feat:","fix:","refactor:","style:","perf:","test:"],
     "regexp": "docs\\(v[0-9]\\): ",
-    "ignoreLabels" : ["meta"]
+    "ignoreLabels" : ["meta", "dependencies"]
   }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: preflight
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,11 @@ jobs:
   preflight:
     runs-on: ubuntu-latest
     steps:
-      - uses: thehanimo/pr-title-checker@v1.3
+      - uses: thehanimo/pr-title-checker@v1.4.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pass_on_octokit_error: false
-          configuration_path: ".github/pr-title-checker-config.json"
+          configuration_path: .github/pr-title-checker-config.json
   build:
     name: Build & Test
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'zulu'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'zulu'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Publish package to the Maven Central Repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
So that the warning by GHA is fixed.